### PR TITLE
chore(deps): updating GitHub Actions to pinned hashes and enable automatic updates for GitHub Actions via Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+   - package-ecosystem: github-actions
+     directory: /
+     schedule:
+        interval: monthly
+     groups:
+        actions:
+           patterns:
+              - '*'

--- a/.github/workflows/docker-deploy.yaml
+++ b/.github/workflows/docker-deploy.yaml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Deploy docker images
-        uses: ethpandaops/github-actions-checker/.github/actions/docker-deploy@0655c7363eb149617d355bf32e4b5f97f3df2cdb
+        uses: ethpandaops/github-actions-checker/.github/actions/docker-deploy@0655c7363eb149617d355bf32e4b5f97f3df2cdb # dependabot/github_actions/actions-b9d97eecc8-0655c73
         with:
           registry: ghcr.io
           registry_username: ${{ github.actor }}

--- a/.github/workflows/lint-golangci.yaml
+++ b/.github/workflows/lint-golangci.yaml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@d6238b002a20823d52840fda27e2d4891c5952dc # v6.5.1
+        uses: golangci/golangci-lint-action@d6238b002a20823d52840fda27e2d4891c5952dc # v4.0.1
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           version: v1.64


### PR DESCRIPTION

### 🔐 Github Actions versions pinning via commit hashes
This PR updates the GitHub Actions to use pinned hashes.

Using version tags like v1 or v2 in GitHub Actions can be risky as the action maintainer can change the underlying code of any tag, or branch.

Pinning to specific commit hashes ensures you're using a specific, immutable version of the action.


### 💚 Dependabot automatic updates
This PR enables automatic updates for GitHub Actions via [Dependabot](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot).

Dependabot will periodically check for new versions of the actions and create a PR to update the version used in the repository.

This should help keeping your GitHub Actions up to date with the latest versions of the actions.

#### 🔍 How was this detected and generated?
This PR was generated using [ethpandaops/github-actions-checker](https://github.com/ethpandaops/github-actions-checker).
